### PR TITLE
add line for proper namespace-package

### DIFF
--- a/freecad/__init__.py
+++ b/freecad/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)


### PR DESCRIPTION
@joha2  https://forum.freecadweb.org/viewtopic.php?f=3&t=32764
the __init__.py file should be removed once py2-support has been disabled.