### PR TITLE
missing subpackage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ setup(
       packages=["pyrateoptics",
                 "tests",
                 "pyrateoptics/core",
+                "pyrateoptics/core/names",
                 "pyrateoptics/raytracer",
                 "pyrateoptics/analysis",
                 "pyrateoptics/io",


### PR DESCRIPTION
I created a package for conda: 
recipe: https://github.com/FreeCAD/FreeCAD_Conda/blob/master/pyrate/meta.yaml
package: https://anaconda.org/freecad/pyrate/files

to install with conda:
1. install miniconda
2. create pyrate environment with freecad:
`conda create -n pyrate pyrate freecad -c freecad/label/dev -c freecad -c conda-forge/label/cf201901`
3. activate pyrate-env
```
source activate pyrate  # unix
activate pyrate # windows
```

FreeCAD (hopefully) will be available with latest conda-forge packages soon. So the command to create the environment will be simpler in the future.