### PR TITLE
Fixing typo: OpticalElement(lc0, label=lenssystem) ... label -> name.

### DIFF
--- a/freecad/PyrateWorkbench/Observer_OpticalSystem.py
+++ b/freecad/PyrateWorkbench/Observer_OpticalSystem.py
@@ -246,7 +246,7 @@ class OpticalSystemObserver(AbstractObserver):
         image = Surface(lc8)
 
 
-        elem = OpticalElement(lc0, label="lenssystem")
+        elem = OpticalElement(lc0, name="lenssystem")
 
         glass = material_isotropic.ConstantIndexGlass(lc0, n=1.7)
         glass2 = material_isotropic.ConstantIndexGlass(lc0, n=1.5)


### PR DESCRIPTION
It was causing error:
Change property: numrays
Running the Python command 'CreateSystemCommand' failed:
Traceback (most recent call last):
  File "/home/martin/.FreeCAD/Mod/pyrate/freecad/PyrateWorkbench/Commands_OpticalSystem.py", line 76, in Activated
    osobs.initFromGivenOpticalSystem(osobs.initDemoSystem())
  File "/home/martin/.FreeCAD/Mod/pyrate/freecad/PyrateWorkbench/Observer_OpticalSystem.py", line 249, in initDemoSystem
    elem = OpticalElement(lc0, label="lenssystem")